### PR TITLE
[UX] Usability Improvements

### DIFF
--- a/model/api.go
+++ b/model/api.go
@@ -8,4 +8,6 @@ type PaperWallet interface {
 	Mnemonic() *MnemonicString
 	Address(index int) (string, error)
 	AddressQR(index int) ([]byte, error)
+	KPubKey() (string)
+	KPubKeyQR() ([]byte, error)
 }

--- a/paper/generate_password.go
+++ b/paper/generate_password.go
@@ -1,5 +1,14 @@
 package paper
+import (
+	"crypto/rand"
+)
 
-func generatePassword() string {
-	return "password" // TODO: v v v secure random password, nobody ever will guess
+func generatePassword() (string, error) {
+	password := make([]byte, 16)
+	_, err := rand.Read(password)
+	if err != nil {
+		return "", err
+	}
+
+	return string(password), nil
 }

--- a/paper/wallet.go
+++ b/paper/wallet.go
@@ -27,7 +27,10 @@ func newWallet(dagParams *dagconfig.Params, mnemonic string) (model.PaperWallet,
 	mnemonicString := &model.MnemonicString{}
 	copy(mnemonicString[:], strings.Split(mnemonic, " ")) // We assume it splits to 24 words
 
-	password := generatePassword()
+	password, err := generatePassword()
+	if err != nil {
+		return nil, err
+	}
 
 	keysFile, err := keys.NewFileFromMnemonic(dagParams, mnemonicString.String(), password)
 	if err != nil {

--- a/paper/wallet.go
+++ b/paper/wallet.go
@@ -58,11 +58,25 @@ func (w *wallet) Address(index int) (string, error) {
 	return address.String(), nil
 }
 
+func (w *wallet) KPubKey() (string) {
+	return w.keysFile.ExtendedPublicKeys[0]
+}
+
 func (w *wallet) AddressQR(index int) ([]byte, error) {
 	address, err := w.Address(index)
 	if err != nil {
 		return nil, err
 	}
+
+	qr, err := qrcode.Encode(address, qrcode.High, 256)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return qr, nil
+}
+
+func (w *wallet) KPubKeyQR() ([]byte, error) {
+	address := w.KPubKey()
 
 	qr, err := qrcode.Encode(address, qrcode.High, 256)
 	if err != nil {

--- a/template.go
+++ b/template.go
@@ -16,6 +16,8 @@ type walletTemplate struct {
 	Mnemonic  *model.MnemonicString
 	Address   string
 	AddressQR string
+	KPubKey   string
+	KPubKeyQR string
 }
 
 func renderWallet(wallet model.PaperWallet) (string, error) {
@@ -53,9 +55,18 @@ func walletToWalletTempalte(wallet model.PaperWallet) (*walletTemplate, error) {
 	}
 	addressQRBase64 := base64.StdEncoding.EncodeToString(addressQRbytes)
 
+	kpubKeyQRbytes, err := wallet.KPubKeyQR()
+	if err != nil {
+		return nil, err
+	}
+	kpubKeyBase64 := base64.StdEncoding.EncodeToString(kpubKeyQRbytes)
+	kpubKey := wallet.KPubKey();
+
 	return &walletTemplate{
 		Mnemonic:  wallet.Mnemonic(),
 		Address:   address,
 		AddressQR: addressQRBase64,
+		KPubKey :  kpubKey,
+		KPubKeyQR: kpubKeyBase64,
 	}, nil
 }

--- a/template.html
+++ b/template.html
@@ -87,28 +87,38 @@
                 font-size: 20pt
             }
 
-            .QR {
-                float:left;
-            }
-
-            .addr {
-                float: right;
-                font-family: monospace;
-                font-size: 30pt;
-                margin-top: 10px;
-                margin-right: 50px;
-                text-align: right;
+            p.address {
+                font-family: 'Courier New', Courier, monospace;
+                font-weight: bolder;
+                word-wrap: break-word;
             }
 
             #QR {
                 outline: 5px solid black;
                 outline-offset: -15px;
-                margin-left: 50px;
+                margin-left: 60px;
+                width: 224px;
+            }
+
+            .QR-item {
+                padding-right: 80px;
+                float: left;  
+                margin-top: 5px;
+            }
+
+            .QR-header {
+                margin-left: 70px;
+                font-size: 20px;
             }
 
             #url {
                 margin-top : -45px;
                 text-align: center;
+            }
+
+            .container {
+                float: left;
+                width: 100%;
             }
             
         </style>
@@ -146,7 +156,10 @@
                 <strong>https://github.com/karlsen-network/karlsen-paper</strong>
             </p>
             <div>
-                <p style="font-family: 'Courier New', Courier, monospace; font-weight: bolder;"> {{.Address}}</p>
+                <p class="address"> 
+                    {{.Address}}
+                    {{.KPubKey}}
+                </p>
                 <h2>Private Key (KEEP PRIVATE!)</h2>
                 <ol id="mnemonic">
                     {{range .Mnemonic}}
@@ -164,15 +177,19 @@
                          alt="K" width="70" style="vertical-align:middle; margin-bottom: 5px; transform: scaleX(-1);" />
                 </h1>
                 <p id = "url">https://github.com/karlsen-network/karlsen-paper</p>
-                <div class = "QR">
-                    <img id = "QR" src="data:image/png;base64, {{.AddressQR}}" alt="Address QR" />
-                </div>
-                <div class="addr">         
-                    {{sub .Address 0 18}}<br>
-                    {{sub .Address 18 30}}<br>
-                    {{sub .Address 30 42}}<br>
-                    {{sub .Address 42 54}}<br>
-                    {{sub .Address 54 67}}<br>
+                <div class='container'>
+                    <div class = "QR-item">
+                        <span class="QR-header">Public Address</span>
+                        <div>
+                            <img id = "QR" src="data:image/png;base64, {{.AddressQR}}" alt="Address QR" />
+                        </div>
+                    </div>
+                    <div class = "QR-item">
+                        <span class="QR-header">Extended Public Key</span>
+                        <div>
+                            <img id = "QR" src="data:image/png;base64, {{.KPubKeyQR}}" alt="Extended Address QR" />
+                        </div>
+                    </div>
                 </div>
             </div>
         </page>


### PR DESCRIPTION
We've and enhanced some of the open upstream PRs:

* Import 24-word mnemonics seeds with small enhancement to show 24-word seed phrase is required at input. Upstream PR: https://github.com/svarogg/kaspaper/pull/8
* Show extended public key QR. Extended public keys QR code is needed for upcoming mobile wallet. We've introduced some small changes to original PR in Kaspaper for better viuals and readability. Upstream PR: https://github.com/svarogg/kaspaper/pull/10 
* Generate strong random password. Upstream PR: https://github.com/svarogg/kaspaper/pull/9

Node operators can now import their 24-word seed phrase, print it and store it in a safe place. Also imported wallets will show already extended pubkey as QR code to transfer KLS with upcoming mobile wallet.