### PR TITLE
[Build] Added linux/aarch64 target build and minor visibility fix

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -9,13 +9,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-    name: Building, ${{ matrix.os }}
+        include:
+          - os: ubuntu-latest
+            TARGET: linux/x86_64
+          - os: ubuntu-latest
+            TARGET: linux/aarch64
+          - os: ubuntu-latest
+            TARGET: windows/x64
+          - os: macos-latest
+            TARGET: macos/x64
+    name: Building, ${{ matrix.TARGET }}
     steps:
-      - name: Fix CRLF on Windows
-        if: runner.os == 'Windows'
-        run: git config --global core.autocrlf false
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
@@ -24,40 +28,75 @@ jobs:
         with:
           go-version: 1.20.12
 
-      - name: Build on Linux
-        if: runner.os == 'Linux'
-        # `-extldflags=-static` - means static link everything,
-        # `-tags netgo,osusergo` means use pure go replacements for "os/user" and "net"
-        # `-s -w` strips the binary to produce smaller size binaries
+      - name: Update sources
+        if: matrix.TARGET == 'linux/aarch64' || matrix.TARGET == 'windows/x64'
+        run: sudo apt-get update -y
+
+      - name: Install compilers
+        if: matrix.TARGET == 'linux/aarch64' || matrix.TARGET == 'windows/x64'
+        run: sudo apt-get install gcc-aarch64-linux-gnu gcc-mingw-w64-x86-64-win32 -y
+
+      - name: Build on Linux for ${{ matrix.TARGET }}
+        if: matrix.TARGET == 'linux/x86_64'
         run: |
+
+          # `-extldflags=-static` - means static link everything,
+          # `-tags netgo,osusergo` means use pure go replacements for "os/user" and "net"
+          # `-s -w` strips the binary to produce smaller size binaries
           go build -v -ldflags="-s -w -extldflags=-static" -tags netgo,osusergo -o ./bin/ .
-          archive="bin/karlsen-paper-${{ github.event.release.tag_name }}-linux.zip"
-          asset_name="karlsen-paper-${{ github.event.release.tag_name }}-linux.zip"
+          archive="bin/karlsen-paper-${{ github.event.release.tag_name }}-linux-x86_64.zip"
+          asset_name="karlsen-paper-${{ github.event.release.tag_name }}-linux-x86_64.zip"
           zip -r "${archive}" ./bin/*
           echo "archive=${archive}" >> $GITHUB_ENV
           echo "asset_name=${asset_name}" >> $GITHUB_ENV
 
-      - name: Build on Windows
-        if: runner.os == 'Windows'
-        shell: bash
+      - name: Build on Linux for ${{ matrix.TARGET }}
+        if: matrix.TARGET == 'linux/aarch64'
+        env:
+          CGO_ENABLED: 1
+          CC: aarch64-linux-gnu-gcc
+          GOOS: linux
+          GOARCH: arm64
         run: |
-          go build -v -ldflags="-s -w" -o bin/ .
-          archive="bin/karlsen-paper-${{ github.event.release.tag_name }}-win64.zip"
-          asset_name="karlsen-paper-${{ github.event.release.tag_name }}-win64.zip"
-          powershell "Compress-Archive bin/* \"${archive}\""
+
+          # `-extldflags=-static` - means static link everything,
+          # `-tags netgo,osusergo` means use pure go replacements for "os/user" and "net"
+          # `-s -w` strips the binary to produce smaller size binaries
+          go build -v -ldflags="-s -w -extldflags=-static" -tags netgo,osusergo -o ./bin/ .
+          archive="bin/karlsen-paper-${{ github.event.release.tag_name }}-linux-aarch64.zip"
+          asset_name="karlsen-paper-${{ github.event.release.tag_name }}-linux-aarch64.zip"
+          zip -r "${archive}" ./bin/*
           echo "archive=${archive}" >> $GITHUB_ENV
           echo "asset_name=${asset_name}" >> $GITHUB_ENV
 
-      - name: Build on MacOS
-        if: runner.os == 'macOS'
+      - name: Build on Linux for ${{ matrix.TARGET }}
+        if: matrix.TARGET == 'windows/x64'
+        env:
+          CGO_ENABLED: 1
+          CC: x86_64-w64-mingw32-gcc
+          GOOS: windows
+          GOARCH: amd64
+        run: |
+
+          # `-extldflags=-static` - means static link everything,
+          # `-tags netgo,osusergo` means use pure go replacements for "os/user" and "net"
+          # `-s -w` strips the binary to produce smaller size binaries
+          go build -v -ldflags="-s -w -extldflags=-static" -tags netgo,osusergo -o ./bin/ .
+          archive="bin/karlsen-paper-${{ github.event.release.tag_name }}-windows-x64.zip"
+          asset_name="karlsen-paper-${{ github.event.release.tag_name }}-windows-x64.zip"
+          zip -r "${archive}" ./bin/*
+          echo "archive=${archive}" >> $GITHUB_ENV
+          echo "asset_name=${asset_name}" >> $GITHUB_ENV
+
+      - name: Build on Linux for ${{ matrix.TARGET }}
+        if: matrix.TARGET == 'macos/x64'
         run: |
           go build -v -ldflags="-s -w" -o ./bin/ .
-          archive="bin/karlsen-paper-${{ github.event.release.tag_name }}-osx.zip"
-          asset_name="karlsen-paper-${{ github.event.release.tag_name }}-osx.zip"
+          archive="bin/karlsen-paper-${{ github.event.release.tag_name }}-macos-x64.zip"
+          asset_name="karlsen-paper-${{ github.event.release.tag_name }}-macos-x64.zip"
           zip -r "${archive}" ./bin/*
           echo "archive=${archive}" >> $GITHUB_ENV
           echo "asset_name=${asset_name}" >> $GITHUB_ENV
-
 
       - name: Upload release asset
         uses: actions/upload-release-asset@v1

--- a/template.html
+++ b/template.html
@@ -158,6 +158,7 @@
             <div>
                 <p class="address"> 
                     {{.Address}}
+                    <br>&nbsp;
                     {{.KPubKey}}
                 </p>
                 <h2>Private Key (KEEP PRIVATE!)</h2>


### PR DESCRIPTION
Small PR with the following changes for next release:

* Added `linux/aarch64` target build on Linux.
* Added `windows/x64` target build on Linux, previous builds were made natively on Windows but cross compilation on same build machine is more predictable.
* Better visibility of extened public key